### PR TITLE
update rules to align with Rescue Line 2024 rules (part 1)

### DIFF
--- a/2.Field.adoc
+++ b/2.Field.adoc
@@ -16,8 +16,6 @@
 
 . Competitors should be aware that tiles may be mounted on thick backing or raised off the ground, which may make it difficult to get back on a tile where the robot comes off the course. No provision will be made to assist robots that drive off of a tile to get back onto the tile.
 
-. Tiles will be used as ramps to allow the robots to "climb" up to and down from different levels. Ramps will not exceed an incline of 25 degrees from the horizontal.
-
 . Robots must be designed so that they can navigate under tiles that form bridges over other tiles. Tiles
 placed above other tiles will be supported by pillars placed at tile corners with a square cross section
 of 25mm x 25mm, making each tile entrance/exit 25 cm. The minimum height (space between the floor and the ceiling) will be 25 cm.
@@ -30,7 +28,7 @@ of 25mm x 25mm, making each tile entrance/exit 25 cm. The minimum height (space 
 
 . The arrangement of the tiles and paths may vary between rounds.
 
-. The line will be 10 cm away from any edge of the field, walls, pillars to support ramps, and obstacles
+. The line will be 10 cm away from any edge of the field, walls, pillars to support ramps, seesaws, and obstacles
 that do not lie ahead of the path of the robot.
 
 image::media/line/line_examples.jpg[]
@@ -80,6 +78,18 @@ different dependent on the organizer.
 . There will be no dead ends.
 
 . The intersections are always perpendicular but may have 3 or 4 branches.
+
+=== Ramps
+
+. Tiles will be used as ramps to allow the robots to 'climb' up and down from different levels.
+
+. Ramps will not exceed an incline of 25 degrees from the horizontal.
+
+. More than one tile may be used to build one ramp up or down. Despite the number of tiles used in the construction, the ramp will be scored as one ramp as it takes from one level to another.
+
+. The ramp will be scored when the robot reaches the horizontal tile at the upper level after an ascending ramp or the horizontal tile at the bottom level after a descending ramp.
+
+. The ramp will have a straight line with no scoring elements present.
 
 === Seesaws
 

--- a/2.Field.adoc
+++ b/2.Field.adoc
@@ -79,6 +79,8 @@ different dependent on the organizer.
 
 . There will be no dead ends.
 
+. The intersections are always perpendicular but may have 3 or 4 branches.
+
 === Seesaws
 
 . A seesaw is comprised of a tile which can pivot around a hinge placed in the centre of a regular tile.
@@ -109,7 +111,7 @@ image::media/line/Seesaw.jpg[]
 
 . Victims may be located anywhere on the floor of the evacuation zone.
 
-. A victim represents a person and is in the form of a 4-5 cm diameter ball with a maximum weight of 80 g.
+. A victim represents a person and is in the form of a 4-5 cm diameter sphere with an off-center center of mass and a maximum weight of 80 g.
 
 . There are two types of victims:
 

--- a/3.Robots.adoc
+++ b/3.Robots.adoc
@@ -20,19 +20,24 @@
 checked during inspection. Teams using lasers must have the datasheet of the laser, and also must
 submit them prior to the competition as well as be able to show them during the competition.
 
-. Wireless communication must be used correctly as described on the https://junior.robocup.org/robocupjunior-general-rules/[RoboCupJunior General Rules].
-Robots performing other types of wireless communication need to be deleted or disabled. If the robot
-has other forms of wireless communication equipment, the team needs to prove that they are
-disabled. Non-conforming robots may be immediately disqualified from the tournament.
+. Wireless communication is only allowed within the robot or between robots of the same SuperTeam during the SuperTeam Challenge.
+It is only allowed to communicate via Bluetooth class 2 or class 3 (range shorter than 20 meters) or via ZigBee.
+Other types of wireless communication equipment need to be removed or disabled.
+If the robot has other wireless communication equipment, the team must prove that this wireless communication is disabled.
+Any form of wireless communication from the robot to external devices is explicitly prohibited.
+Non-conforming robots may be immediately disqualified from the tournament.
+Teams are responsible for their communication.
+The availability of frequencies cannot be guaranteed.
 
 . Robots may incur damage by falling off the field, making contact with another robot, or making contact with field elements.  The organizing committee cannot anticipate all potential situations where damage to the robot may occur. Teams should ensure that all active elements on a robot are properly protected with resistant materials. For example, electrical circuits must be protected from all human contact and direct contact with other robots and field elements.
 
 . When batteries are transported, moved or charged, it is strongly recommended that safety bags be used. Reasonable efforts should be made to ensure that robots avoid short circuits and chemical or air leaks.
 
-. Robots must be equipped with a handle which is to be used to pick them up during the scoring run.
+. *Robots must be equipped with a handle that is to be used to pick them up during the scoring run.*
 
-. Robots must be equipped with a single binary switch or button(s) or any kind, clearly visible to
-the referee, specifically for restarting the robot when a lack of progress occurs.
+. *Robots must be equipped with a single physical binary switch/button (with exception of buttons that are a part of commercial controller), clearly visible to the referee, for starting the robot at the begining of the run and when a lack of progress occurs.
+Procedure performed after LoP occurs can only include this button and at most one more switch for cutting the power.
+Team has to notify the referee about their LoP procedure before each scoring run, and only this procedure is allowed to be performed after a LoP.*
 
 === Team
 
@@ -67,13 +72,22 @@ final (e.g. German Open, Portuguese Open, etc.). A participant is allowed to par
 
 . Students will be asked about their preparation efforts and may be requested to answer surveys and participate in video-taped interviews for research purposes.
 
-. All teams must complete a web form prior to the competition to allow referees to better prepare for the interviews.  Instructions on how to submit the form will be provided to the teams prior to the competition.
+. All teams must complete a web form prior to the competition to allow referees to better prepare for the interviews.  Instructions on how to submit the form will be provided to the teams at least 4 weeks before the competition.
 
 . All teams have to submit their source code prior to the competition. The source code will not be shared with other teams without the team’s permission.
 
 . All teams must submit their engineering journal prior to the competition. The journals will not be shared with other teams without the team’s permission.
+The organizers will request permission at the registration.
+A guide for the Engineering Journal format is available
+on the https://junior.robocup.org/rcj-rescue-line/[RoboCupJunior Official website].
 
 NOTE: However, it is highly recommended that teams publicly share their engineering journal. With the teams that indicate that their engineering journals could be shared publicly during the registration process, the journal alongside their poster presentation will be shared through the RoboCupJunior Forum so that other teams could learn from them.
+
+. All teams must submit a Poster file before the competition and bring a physical Poster to the competition venue.
+The Poster is a public document that will be shared with the community during the Poster Presentation session at the competiiton venue.
+A template for the Poster is available on the https://junior.robocup.org/rcj-rescue-line/[RoboCupJunior Official website].
+
+. The deadline for delivering the documents is scheduled for 3 weeks before the first day of the competition.
 
 === Violations
 

--- a/4.Play.adoc
+++ b/4.Play.adoc
@@ -79,7 +79,7 @@ NOTE: "sequence" is not including diagonal sequence
 
 . If a lack of progress occurs, the robot must be positioned on the previous checkpoint tile facing the path towards the evacuation zone and checked by the referee.
 
-. After a lack of progress, the team must reset the robot by using a switch/button(s) located in a clearly visible location by the referee (see 3.2.8).
+. After a lack of progress, only the LoP procedure explained to the referee before the run start is allowed to be performed (see 3.2.8).
 +
 image::media/maze/restart_actions.jpg[float="left"]
 

--- a/4.Play.adoc
+++ b/4.Play.adoc
@@ -66,7 +66,7 @@ ensure the difficulty of the field will be kept similar and the maximum points t
 
 . The robot must follow the course completely to enter the evacuation zone.
 
-. The robot has visited a tile when more than half the robot is within that tile when viewed from above.
+. The robot has reached a tile when more than half the robot is within that tile when viewed from above and the robot is actively following the line at that point in time.
 
 === Lack of Progress
 
@@ -100,13 +100,12 @@ image::media/line/lack_of_progress.png[float="left"]
 . A robot is awarded points for successfully navigating each hazard (gaps in the line, speed bumps,
 intersections, ramps, obstacles, and seesaws). Points are awarded per hazard when the
 robot has reached the subsequent tile in sequence. A ramp as a hazard accounts for all of the
-inclined tiles that make up one ramp. Point allocations are, 10 points per gap, 15 points per obstacle,
-10 points per intersection, 10 points per ramp, 5 points per speed bump, and 15 points per
-seesaw.
+inclined tiles that make up one ramp.
+Point allocations are 10 points per tile with one or more gaps, 10 points per tile with one or more speed bumps, 10 points per intersection, 10 points per ramp, 20 points per obstacle, and 20 points per seesaw.
 
 . Failed attempts at navigating hazards in the field are defined as a Lack of Progress (see <<Lack of Progress>>).
 
-. When a robot reaches a checkpoint tile it will earn points for each tile it has passed since the previous checkpoint. The points per tile depend on how many attempts the robot has made to reach the checkpoint:
+. When a robot reaches a checkpoint tile, it will earn points for each tile it has passed since the previous checkpoint. The points per tile depend on how many attempts the robot has made to reach the checkpoint:
 
 * 1st attempt = 5 points/tile
 * 2nd attempt = 3 points/tile
@@ -116,7 +115,7 @@ seesaw.
 image::media/line/tile_scoring_example_1.png[float="left"]
 image::media/line/scoring.JPG[float="left"]
 
-. Each gap, speed bump, intersection, dead end, obstacle, ramp, and seesaw can only be scored once
+. Each gap, speed bump, intersection, obstacle, ramp, and seesaw can only be scored once
 per intended direction through the course. Points are not awarded for subsequent attempts through
 the course.
 
@@ -132,7 +131,7 @@ been successfully evacuated.
 .. x1.2 if only the dead victim is evacuated
 
 . When a lack of progress occurs inside of the evacuation zone, 0.05 will be
-deducted from each of the obtained multiplier (however multipliers will not be less than 1).
+deducted from each of the obtained multiplier (however multipliers will not be less than 1.25).
 
 . Multiplier values obtained throughout the scoring run will be directly multiplied together to the sum
 of all the other points gained during the scoring run.

--- a/5.Competition.adoc
+++ b/5.Competition.adoc
@@ -1,0 +1,25 @@
+== Competition
+
+This chapter outlines the structure of an international RoboCupJunior Rescue competition.
+The competition format and the inclusion of elements like the SuperTeam Challenge may vary in local, regional and super-regional competitions.
+Please refer to the respective organiser for details.
+
+=== Rounds & Scoring
+
+. The competition will consist of multiple rounds of which the worst one or more will be omitted from the final score.
+
+=== Technical Challenge
+
+There will be no Technical Challenge (see Rescue Line rules for reference).
+
+=== SuperTeam Challenge
+
+The SuperTeam Challenge takes place independantly of the main competition and won’t influence the team’s individual score.
+It has its own award and is focussed on the cooperation between the teams.
+
+. Each SuperTeam will consist of at least two teams.
+Teams coming from regions that share a native language will not be part of the same SuperTeam.
+
+. The rules of the SuperTeam Challenge will be announced at the competition and require the teams of each SuperTeam to work together.
+
+. The SuperTeam Challenge will require substantial software changes and may require minor hardware adjustments.

--- a/6.OpenTechnicalEvaluation.adoc
+++ b/6.OpenTechnicalEvaluation.adoc
@@ -24,6 +24,8 @@
 
 . Teams must provide documents that explain their work. Each invention must be supported by concise but clear documentation. The documents must show precise steps towards the creation of the invention.
 
+. The deadline for delivering the documents is scheduled for 3 weeks before the first day of the competition through an online form.
+
 . Documents must include one poster and one engineering journal (see the Engineering Journal Template on official RCJ website for more details). Teams should be prepared to explain their work.
 
 . Engineering Journals should demonstrate your best practices in the development process.

--- a/7.ConflictResolution.adoc
+++ b/7.ConflictResolution.adoc
@@ -18,5 +18,5 @@
 
 . If special circumstances, such as unforeseen problems or capabilities of a robot occur, rules may be modified by the RoboCupJunior Rescue Line Entry Working Group Chair in conjunction with available Technical Committee and Organizing Committee members, even during a tournament.
 
-. If any of the team captains/mentors do not show up to the team meetings to discuss problems and the resulting rule modifications described at 6.3.1, it will be understood that they agreed and were aware of the changes.
+. If any of the team captains/mentors do not show up to the team meetings to discuss problems and the resulting rule modifications described at 7.3.1, it will be understood that they agreed and were aware of the changes.
 

--- a/rule.adoc
+++ b/rule.adoc
@@ -122,6 +122,8 @@ include::3.Robots.adoc[]
 
 include::4.Play.adoc[]
 
-include::5.OpenTechnicalEvaluation.adoc[]
+include::5.Competition.adoc[]
 
-include::6.ConflictResolution.adoc[]
+include::6.OpenTechnicalEvaluation.adoc[]
+
+include::7.ConflictResolution.adoc[]

--- a/rule.adoc
+++ b/rule.adoc
@@ -96,16 +96,19 @@ An autonomous robot should follow a black line while overcoming different proble
 
 Teams are not allowed to give their robot any information in advance about the field as the robot is supposed to recognize the field by itself. The robot earns points as follows:
 
-* 15 points for navigating through a seesaw tile
-* 15 points for overcoming an obstacle (bricks, blocks, weights and other large, heavy items). A robot is expected to navigate the various obstacles.
-* 10 points for reacquiring the line after a gap
-* 10 points for successfully navigating through a ramp (i.e. up and down successfully)
-* 5 points for negotiating a speed bump.
+* 10 points for following the correct path on a tile at an intersection.
+* 20 points for navigating through a seesaw tile.
+* 20 points for overcoming each obstacle (bricks, blocks, weights, and other large, heavy items). A robot is expected to navigate various obstacles.
+* 10 points for reacquiring the line after a tile with one or more gaps.
+* 10 points for successfully navigating through a ramp (i.e., up or down successfully).
+* 10 points for negotiating a tile with one or more speed bumps.
 
 If the robot gets stuck in the field, it can be restarted at the last visited checkpoint. The robot will earn points when it reaches new checkpoints. At the end of the path there will be a rectangular zone with walls (the evacuation zone). The entrance to this zone will be marked with a strip of reflective silver tape on the floor.
 
-Once inside the evacuation zone, the robot should locate and transport as many victims (reflective silver balls of 4-5 cm diameter that are electrically conductive) as possible to an evacuation point in one of the corners of the room. The robot can earn multipliers for
-victim evacuations.
+Once in the evacuation zone, the robot should locate and transport the victims to the designated evacuation points.
+The victims are represented by spheres with an off-center center of mass of 4 to 5 cm in diameter.
+The live victims are reflective silver which is electrically conductive, and the dead victims are black, which is not electrically conductive.
+The team can earn multipliers for victim evacuations.
 
 <<<
 toc::[]


### PR DESCRIPTION
Changes:
- updated scores for hazards (now aligns with [Rescue Line 2024 rules](https://junior.robocup.org/wp-content/uploads/2024/01/RCJRescueLine2024-final.pdf))
- add separate section for ramps (Line 2.7)
- victims (off-center center of mass)
- multipliers at least 1.25
- smaller fixes
- add deadlines for document submissions
- add section 5 (Competition) with SuperTeam etc.

PDF is not updated, only the source code

Deviations from Rescue Line rules:
- no scoring elements on the ramp (vs. Line 2.7.5)
- Line 3.2.4: don't mention Rescue Challenge in wireless communication
- Line "5. Competition": omit rubrics-based scoring and Technical Challenge
  - TODO: should the Technical challenge be included?
  - TODO: should poster and journal (and technical challenge) be included in the scoring?

Less important changes in Rescue Line rules:
- some rephrasings over the years
- they don't mention a dice anymore for deciding the evacuation point corner
